### PR TITLE
Add Google Sheets export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ REDIS_PORT =
 REDIS_HOST =
 REDIS_PASSWORD =
 NEXT_PUBLIC_BASE_URL = "Enter base url of you deployment"
+GOOGLE_SHEETS_WEBHOOK_URL = "Webhook URL for saving tweets to Google Sheets"
 ```
 
 ## Screenshots

--- a/src/app/api/google-sheets/route.ts
+++ b/src/app/api/google-sheets/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const { tweet } = await req.json();
+  const webhookUrl = process.env.GOOGLE_SHEETS_WEBHOOK_URL;
+
+  if (!webhookUrl) {
+    return NextResponse.json(
+      { message: "Google Sheets webhook URL not configured" },
+      { status: 500 }
+    );
+  }
+
+  if (!tweet) {
+    return NextResponse.json(
+      { message: "Tweet text is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ tweet }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to export tweet: ${response.statusText}`);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error exporting tweet to Google Sheets:", error);
+    return NextResponse.json(
+      { message: "Failed to export tweet" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/components/InteractiveForm.tsx
+++ b/src/app/components/InteractiveForm.tsx
@@ -4,6 +4,7 @@ import axios, { isAxiosError } from "axios";
 import { useEffect, useState } from "react";
 import toast, { Toaster } from "react-hot-toast";
 import {  BsCopy } from "react-icons/bs";
+import { RiFileAddLine } from "react-icons/ri";
 import { Button } from "./Button";
 import PromptForm from "./PromptForm";
 import Dropdown from "./Dropdown";
@@ -20,7 +21,29 @@ const InteractiveForm = () => {
   const [loading, setLoading] = useState<boolean>(false);
   const [mounted, setMounted] = useState(false);
   const [selectedOptions, setSelectedOptions] = useState<Record<string,string>>(
-    tweetCategories.reduce((acc, category) => ({...acc, [category.key]: ''}), {}));
+    tweetCategories.reduce((acc, category) => ({ ...acc, [category.key]: '' }), {})
+  );
+
+  const exportTweet = async (tweet: string) => {
+    try {
+      await axios.post(
+        BASE_URL + "/api/google-sheets",
+        JSON.stringify({ tweet }),
+        { headers: { "Content-Type": "application/json" } }
+      );
+      toast("Saved to Google Sheets", {
+        icon: "✅",
+        style: {
+          borderRadius: "10px",
+          background: "#333",
+          color: "#fff",
+        },
+      });
+    } catch (error) {
+      console.error("Error exporting tweet:", error);
+      toast.error("Failed to save tweet to Google Sheets");
+    }
+  };
 
   useEffect(() => {
     setMounted(true);
@@ -133,6 +156,12 @@ const InteractiveForm = () => {
             className="text-[12px] flex items-center gap-1 bg-gray-800 text-white px-4 py-2 rounded-md hover:bg-gray-700 absolute right-1 top-1"
             >
             <BsCopy size={15} /> Copy
+          </Button>
+          <Button
+            onClick={() => exportTweet(tweet)}
+            className="text-[12px] flex items-center gap-1 bg-gray-800 text-white px-4 py-2 rounded-md hover:bg-gray-700 absolute right-1 bottom-1"
+          >
+            <RiFileAddLine size={15} /> Save
           </Button>
           <Toaster position="top-center" reverseOrder={false} />
         </div>


### PR DESCRIPTION
## Summary
- export tweets to a Google Sheet through new API route
- add Save to Sheets button for generated tweets
- document `GOOGLE_SHEETS_WEBHOOK_URL` environment variable

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*