### PR TITLE
Add direct Google Sheets integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,16 @@ REDIS_PORT =
 REDIS_HOST =
 REDIS_PASSWORD =
 NEXT_PUBLIC_BASE_URL = "Enter base url of you deployment"
-GOOGLE_SHEETS_WEBHOOK_URL = "Webhook URL for saving tweets to Google Sheets"
+GOOGLE_SHEETS_WEBHOOK_URL = "Webhook URL for saving tweets to Google Sheets (optional)"
+GOOGLE_SHEETS_SPREADSHEET_ID = "Google Spreadsheet ID"
+GOOGLE_SHEETS_CLIENT_EMAIL = "Service account client email"
+GOOGLE_SHEETS_PRIVATE_KEY = "Service account private key"
+GOOGLE_SHEETS_SHEET_NAME = "Worksheet name (optional, defaults to Sheet1)"
 ```
+
+If `GOOGLE_SHEETS_WEBHOOK_URL` is omitted, the API route uses the Google Sheets API
+with the above credentials to append each tweet to the first empty row of the
+specified worksheet.
 
 ## Screenshots
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "axios": "^1.7.9",
+        "googleapis": "^132.0.0",
         "ioredis": "^5.4.2",
         "next": "15.1.5",
         "openai": "^4.28.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@google/generative-ai": "^0.21.0",
     "openai": "^4.28.0",
     "axios": "^1.7.9",
+    "googleapis": "^132.0.0",
     "ioredis": "^5.4.2",
     "next": "15.1.5",
     "react": "^19.0.0",

--- a/src/app/api/google-sheets/route.ts
+++ b/src/app/api/google-sheets/route.ts
@@ -1,15 +1,9 @@
 import { NextResponse } from "next/server";
+import { appendTweetToSheet } from "../../lib/googleSheets";
 
 export async function POST(req: Request) {
   const { tweet } = await req.json();
   const webhookUrl = process.env.GOOGLE_SHEETS_WEBHOOK_URL;
-
-  if (!webhookUrl) {
-    return NextResponse.json(
-      { message: "Google Sheets webhook URL not configured" },
-      { status: 500 }
-    );
-  }
 
   if (!tweet) {
     return NextResponse.json(
@@ -18,19 +12,32 @@ export async function POST(req: Request) {
     );
   }
 
-  try {
-    const response = await fetch(webhookUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ tweet }),
-    });
+  if (webhookUrl) {
+    try {
+      const response = await fetch(webhookUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tweet }),
+      });
 
-    if (!response.ok) {
-      throw new Error(`Failed to export tweet: ${response.statusText}`);
+      if (!response.ok) {
+        throw new Error(`Failed to export tweet: ${response.statusText}`);
+      }
+
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      console.error("Error exporting tweet to Google Sheets:", error);
+      return NextResponse.json(
+        { message: "Failed to export tweet" },
+        { status: 500 }
+      );
     }
+  }
 
+  try {
+    await appendTweetToSheet(tweet);
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Error exporting tweet to Google Sheets:", error);

--- a/src/app/lib/googleSheets.ts
+++ b/src/app/lib/googleSheets.ts
@@ -1,0 +1,31 @@
+import { google } from 'googleapis';
+
+export async function appendTweetToSheet(tweet: string) {
+  const spreadsheetId = process.env.GOOGLE_SHEETS_SPREADSHEET_ID;
+  const clientEmail = process.env.GOOGLE_SHEETS_CLIENT_EMAIL;
+  const privateKey = process.env.GOOGLE_SHEETS_PRIVATE_KEY;
+  const sheetName = process.env.GOOGLE_SHEETS_SHEET_NAME || 'Sheet1';
+
+  if (!spreadsheetId || !clientEmail || !privateKey) {
+    throw new Error('Google Sheets environment variables not configured');
+  }
+
+  const auth = new google.auth.JWT(
+    clientEmail,
+    undefined,
+    privateKey.replace(/\\n/g, '\n'),
+    ['https://www.googleapis.com/auth/spreadsheets']
+  );
+
+  const sheets = google.sheets({ version: 'v4', auth });
+
+  await sheets.spreadsheets.values.append({
+    spreadsheetId,
+    range: `${sheetName}!A:A`,
+    valueInputOption: 'USER_ENTERED',
+    insertDataOption: 'INSERT_ROWS',
+    requestBody: {
+      values: [[tweet]],
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- integrate with Google Sheets API using service account
- fall back to webhook if `GOOGLE_SHEETS_WEBHOOK_URL` is set
- document required environment variables for Google Sheets
- add `googleapis` dependency

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*