### PR TITLE
Fix options payload when generating tweets

### DIFF
--- a/src/app/components/InteractiveForm.tsx
+++ b/src/app/components/InteractiveForm.tsx
@@ -95,8 +95,8 @@ const InteractiveForm = () => {
     try {
       const response = await axios.post(
         BASE_URL + "/api/submit",
-        { description, selectedOptions, apiKey },
-        { 
+        { description, options: selectedOptions, apiKey },
+        {
           headers: {
             'Content-Type': 'application/json'
           }


### PR DESCRIPTION
## Summary
- update InteractiveForm to send `options` field

## Testing
- `npm run lint` *(fails: next not found)*