### PR TITLE
Fix base url handling for API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,15 @@ GEMINI_AI_API_KEY = "Your gemini api key"
 REDIS_PORT =
 REDIS_HOST =
 REDIS_PASSWORD =
-NEXT_PUBLIC_BASE_URL = "Enter base url of you deployment"
+NEXT_PUBLIC_BASE_URL = "Base url of your deployment (optional)"
 GOOGLE_SHEETS_WEBHOOK_URL = "Webhook URL for saving tweets to Google Sheets (optional)"
 GOOGLE_SHEETS_SPREADSHEET_ID = "Google Spreadsheet ID"
 GOOGLE_SHEETS_CLIENT_EMAIL = "Service account client email"
 GOOGLE_SHEETS_PRIVATE_KEY = "Service account private key"
 GOOGLE_SHEETS_SHEET_NAME = "Worksheet name (optional, defaults to Sheet1)"
 ```
+
+If `NEXT_PUBLIC_BASE_URL` is not provided, the frontend uses relative paths for API requests.
 
 If `GOOGLE_SHEETS_WEBHOOK_URL` is omitted, the API route uses the Google Sheets API
 with the above credentials to append each tweet to the first empty row of the

--- a/src/app/components/InteractiveForm.tsx
+++ b/src/app/components/InteractiveForm.tsx
@@ -10,10 +10,9 @@ import PromptForm from "./PromptForm";
 import Dropdown from "./Dropdown";
 import tweetCategories, { TweetCategory } from "../lib/data";
 
-const BASE_URL: string =
-  process.env.NODE_ENV == "production"
-    ? "https://twitter-post-genai.vercel.app"
-    : "http://localhost:3000";
+// Resolve API base URL from environment. When NEXT_PUBLIC_BASE_URL is not set,
+// fall back to relative paths so API calls work in any deployment.
+const BASE_URL: string = process.env.NEXT_PUBLIC_BASE_URL || "";
 
 const InteractiveForm = () => {
   const [description, setDescription] = useState<string>("");


### PR DESCRIPTION
## Summary
- read `NEXT_PUBLIC_BASE_URL` when calling API routes
- document optional NEXT_PUBLIC_BASE_URL usage in README

## Testing
- `npm run lint` *(fails: next not found)*