### PR TITLE
Fix Google Sheets webhook export

### DIFF
--- a/src/app/api/google-sheets/route.ts
+++ b/src/app/api/google-sheets/route.ts
@@ -2,8 +2,8 @@ import { NextResponse } from "next/server";
 import { appendTweetToSheet } from "../../lib/googleSheets";
 
 export async function POST(req: Request) {
-  const { tweet } = await req.json();
-  const webhookUrl = process.env.GOOGLE_SHEETS_WEBHOOK_URL;
+  const { tweet, webhookUrl: clientWebhookUrl } = await req.json();
+  const webhookUrl = clientWebhookUrl || process.env.GOOGLE_SHEETS_WEBHOOK_URL;
 
   if (!tweet) {
     return NextResponse.json(

--- a/src/app/components/InteractiveForm.tsx
+++ b/src/app/components/InteractiveForm.tsx
@@ -34,27 +34,13 @@ const InteractiveForm = () => {
   const exportTweet = async (tweet: string) => {
     const loadingToast = toast.loading("Saving tweet...");
     try {
-      let response;
-      
-      if (webhookUrl) {
-        // Direct webhook request
-        response = await fetch(webhookUrl, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ tweet }),
-        });
-      } else {
-        // Local API route request
-        response = await fetch(`${BASE_URL}/api/google-sheets`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ tweet }),
-        });
-      }
+      const response = await fetch(`${BASE_URL}/api/google-sheets`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ tweet, webhookUrl }),
+      });
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
## Summary
- always POST tweets to local API with optional webhook URL
- allow `/api/google-sheets` route to use a webhook URL from the request body

## Testing
- `npx next lint` *(fails: request to https://registry.npmjs.org/next failed)*