### PR TITLE
Improve error reporting for failed Google Sheets export

### DIFF
--- a/src/app/api/google-sheets/route.ts
+++ b/src/app/api/google-sheets/route.ts
@@ -36,6 +36,18 @@ export async function POST(req: Request) {
     }
   }
 
+  // When no webhook is provided, ensure that Google Sheets credentials exist
+  if (
+    !process.env.GOOGLE_SHEETS_SPREADSHEET_ID ||
+    !process.env.GOOGLE_SHEETS_CLIENT_EMAIL ||
+    !process.env.GOOGLE_SHEETS_PRIVATE_KEY
+  ) {
+    return NextResponse.json(
+      { message: "Google Sheets configuration not found" },
+      { status: 500 }
+    );
+  }
+
   try {
     await appendTweetToSheet(tweet);
     return NextResponse.json({ success: true });

--- a/src/app/components/InteractiveForm.tsx
+++ b/src/app/components/InteractiveForm.tsx
@@ -43,7 +43,9 @@ const InteractiveForm = () => {
       });
 
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+        const data = await response.json().catch(() => null);
+        const message = data?.message || `HTTP error! status: ${response.status}`;
+        throw new Error(message);
       }
       
       toast.dismiss(loadingToast);


### PR DESCRIPTION
## Summary
- better error handling when /api/google-sheets is misconfigured
- surface server error message to client when exporting tweet

## Testing
- `npm run lint` *(fails: `next` not found)*