### PR TITLE
Add tweet scheduler using Google Sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@ An AI-driven tool that generates creative and engaging tweet ideas based on user
 4. Start the server
 
 ```bash
-  npm run dev
+ npm run dev
+```
+
+5. Start the scheduler (optional)
+
+```bash
+  npm run start:scheduler
 ```
 
 ## Environment Variables
@@ -71,6 +77,10 @@ GOOGLE_SHEETS_SPREADSHEET_ID = "Google Spreadsheet ID"
 GOOGLE_SHEETS_CLIENT_EMAIL = "Service account client email"
 GOOGLE_SHEETS_PRIVATE_KEY = "Service account private key"
 GOOGLE_SHEETS_SHEET_NAME = "Worksheet name (optional, defaults to Sheet1)"
+TWITTER_API_KEY = "Twitter API key"
+TWITTER_API_SECRET = "Twitter API secret"
+TWITTER_ACCESS_TOKEN = "Twitter access token"
+TWITTER_ACCESS_SECRET = "Twitter access secret"
 ```
 
 If `NEXT_PUBLIC_BASE_URL` is not provided, the frontend uses relative paths for API requests.
@@ -78,6 +88,9 @@ If `NEXT_PUBLIC_BASE_URL` is not provided, the frontend uses relative paths for 
 If `GOOGLE_SHEETS_WEBHOOK_URL` is omitted, the API route uses the Google Sheets API
 with the above credentials to append each tweet to the first empty row of the
 specified worksheet.
+
+The scheduler uses the Twitter environment variables above to post tweets
+automatically based on entries in your Google Sheet.
 
 ## Screenshots
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "start:scheduler": "node src/app/lib/scheduler.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
@@ -18,7 +19,9 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.5.1",
-    "react-icons": "^5.4.0"
+    "react-icons": "^5.4.0",
+    "node-cron": "^3.0.3",
+    "twitter-api-v2": "^1.15.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/lib/scheduler.ts
+++ b/src/app/lib/scheduler.ts
@@ -1,0 +1,56 @@
+import cron from 'node-cron';
+import { google } from 'googleapis';
+import { sendTweet } from './twitterClient';
+
+const spreadsheetId = process.env.GOOGLE_SHEETS_SPREADSHEET_ID;
+const clientEmail = process.env.GOOGLE_SHEETS_CLIENT_EMAIL;
+const privateKey = process.env.GOOGLE_SHEETS_PRIVATE_KEY;
+const sheetName = process.env.GOOGLE_SHEETS_SHEET_NAME || 'Sheet1';
+
+if (!spreadsheetId || !clientEmail || !privateKey) {
+  throw new Error('Google Sheets environment variables not configured');
+}
+
+const auth = new google.auth.JWT(
+  clientEmail,
+  undefined,
+  privateKey.replace(/\\n/g, '\n'),
+  ['https://www.googleapis.com/auth/spreadsheets']
+);
+
+const sheets = google.sheets({ version: 'v4', auth });
+
+async function processSheet() {
+  const now = new Date();
+  const res = await sheets.spreadsheets.values.get({
+    spreadsheetId,
+    range: `${sheetName}!A:C`,
+  });
+  const rows = res.data.values || [];
+  for (let i = 1; i < rows.length; i++) {
+    const [content, dateStr, posted] = rows[i];
+    if (posted && posted.toLowerCase() === 'true') continue;
+    if (!content || !dateStr) continue;
+    const scheduled = new Date(dateStr);
+    if (scheduled <= now) {
+      try {
+        await sendTweet(content);
+        await sheets.spreadsheets.values.update({
+          spreadsheetId,
+          range: `${sheetName}!C${i + 1}`,
+          valueInputOption: 'USER_ENTERED',
+          requestBody: { values: [['TRUE']] },
+        });
+        console.log(`Tweet posted for row ${i + 1}`);
+      } catch (err) {
+        console.error('Error posting tweet:', err);
+      }
+    }
+  }
+}
+
+cron.schedule('*/5 * * * *', () => {
+  processSheet().catch((e) => console.error(e));
+});
+
+processSheet().catch((e) => console.error(e));

--- a/src/app/lib/twitterClient.ts
+++ b/src/app/lib/twitterClient.ts
@@ -1,0 +1,13 @@
+import { TwitterApi } from 'twitter-api-v2';
+
+const client = new TwitterApi({
+  appKey: process.env.TWITTER_API_KEY || '',
+  appSecret: process.env.TWITTER_API_SECRET || '',
+  accessToken: process.env.TWITTER_ACCESS_TOKEN || '',
+  accessSecret: process.env.TWITTER_ACCESS_SECRET || '',
+});
+
+export async function sendTweet(text: string) {
+  if (!text) return;
+  await client.v2.tweet(text);
+}


### PR DESCRIPTION
## Summary
- add node-cron based scheduler to read tweets from Google Sheets and post them
- integrate twitter-api-v2 client for tweeting
- document Twitter environment vars and scheduler usage
- expose npm script `start:scheduler`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b9ff6b49483249b39ab6e96eaf203