### PR TITLE
Add pdf summary runtime config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Instructions for Codex
+
+- After making changes, always run `npm run lint` and `npm run build`.
+- If a `test` script exists, run `npm run test`; otherwise note "No test script".
+- Provide a summary of these commands' results in the PR description.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An AI-driven tool that generates creative and engaging tweet ideas based on user
 - 🔒 Secure and private user data.
 - 🚀 Built-in rate limiting for fair use.
 - 🛠️ Easy integration via REST API.
+- 📄 Upload a PDF to receive a summary with bullet points.
 
 ## Tech Stack
 
@@ -29,6 +30,17 @@ An AI-driven tool that generates creative and engaging tweet ideas based on user
 | Parameter     | Type     | Description                              |
 | :------------ | :------- | :--------------------------------------- |
 | `description` | `string` | Specify your requirements for the tweet. |
+
+#### Summarize PDF
+
+```http
+  POST /api/summarize-pdf
+```
+
+| Parameter | Type | Description |
+| :-------- | :--- | :---------- |
+| `file`    | `PDF` | PDF file to summarize |
+| `apiKey`  | `string` | Your OpenAI API key |
 
 ## Run Locally
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.5.1",
-    "react-icons": "^5.4.0"
+    "react-icons": "^5.4.0",
+    "pdf-parse": "^1.1.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pdf-parse.d.ts
+++ b/pdf-parse.d.ts
@@ -1,0 +1,1 @@
+declare module 'pdf-parse';

--- a/src/app/api/summarize-pdf/route.ts
+++ b/src/app/api/summarize-pdf/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import OpenAI from "openai";
+import pdfParse from "pdf-parse";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  const formData = await req.formData();
+  const file = formData.get("file") as File | null;
+  const apiKey = formData.get("apiKey") as string | null;
+
+  if (!file) {
+    return NextResponse.json({ message: "PDF file is required" }, { status: 400 });
+  }
+  if (!apiKey) {
+    return NextResponse.json({ message: "API key is required" }, { status: 400 });
+  }
+
+  try {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const data = await pdfParse(buffer);
+    const text = data.text.slice(0, 15000);
+
+    const openai = new OpenAI({ apiKey });
+    const completion = await openai.chat.completions.create({
+      model: "gpt-4",
+      messages: [
+        { role: "system", content: "You summarize PDF text and respond in JSON." },
+        { role: "user", content: `Summarize the following text in one short paragraph and list 3-5 bullet points highlighting the key ideas. Respond in JSON with keys 'summary' and 'bullets'. Text:\n${text}` }
+      ],
+      temperature: 0.5,
+    });
+
+    const content = completion.choices[0].message?.content || "";
+    let summary = "";
+    let bullets: string[] = [];
+    try {
+      const parsed = JSON.parse(content);
+      summary = parsed.summary;
+      bullets = parsed.bullets;
+    } catch {
+      summary = content;
+    }
+
+    return NextResponse.json({ summary, bullets });
+  } catch (error) {
+    console.error("Error summarizing PDF:", error);
+    return NextResponse.json({ message: "Failed to summarize PDF" }, { status: 500 });
+  }
+}

--- a/src/app/components/PdfSummaryForm.tsx
+++ b/src/app/components/PdfSummaryForm.tsx
@@ -1,0 +1,97 @@
+"use client";
+import { useState } from "react";
+import toast, { Toaster } from "react-hot-toast";
+
+const BASE_URL: string = process.env.NEXT_PUBLIC_BASE_URL || "";
+
+interface SummaryResult {
+  summary: string;
+  bullets: string[];
+}
+
+const PdfSummaryForm = () => {
+  const [file, setFile] = useState<File | null>(null);
+  const [apiKey, setApiKey] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<SummaryResult | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!file) return;
+    setLoading(true);
+
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("apiKey", apiKey);
+
+    try {
+      const response = await fetch(`${BASE_URL}/api/summarize-pdf`, {
+        method: "POST",
+        body: formData,
+      });
+      if (!response.ok) {
+        throw new Error("Failed to summarize PDF");
+      }
+      const data = await response.json();
+      setResult(data);
+      toast.success("Summarized successfully", {
+        style: {
+          borderRadius: "10px",
+          background: "#333",
+          color: "#fff",
+        },
+      });
+    } catch (error) {
+      console.error("Error summarizing PDF:", error);
+      toast.error("Failed to summarize PDF");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="w-full max-w-2xl">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <input
+          type="password"
+          placeholder="Enter your OpenAI API key"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          className="w-full bg-transparent border-2 border-gray-800 rounded-lg p-2.5 text-gray-100 shadow focus:outline-none focus:ring-2 focus:ring-gray-800 placeholder:text-gray-500"
+        />
+        <input
+          type="file"
+          accept="application/pdf"
+          onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+          className="w-full text-gray-100"
+        />
+        <button
+          type="submit"
+          className="bg-gray-800 text-white px-4 py-2 rounded-md hover:bg-gray-700"
+          disabled={loading}
+        >
+          {loading ? "Summarizing..." : "Summarize PDF"}
+        </button>
+      </form>
+      {result && (
+        <div className="mt-4 text-gray-100">
+          <h3 className="font-semibold mb-2">Summary</h3>
+          <p className="mb-2 whitespace-pre-line">{result.summary}</p>
+          {result.bullets && result.bullets.length > 0 && (
+            <>
+              <h3 className="font-semibold mb-1">Bullet Points</h3>
+              <ul className="list-disc list-inside">
+                {result.bullets.map((b, i) => (
+                  <li key={i}>{b}</li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      )}
+      <Toaster position="top-center" reverseOrder={false} />
+    </div>
+  );
+};
+
+export default PdfSummaryForm;

--- a/src/app/pdf-summary/page.tsx
+++ b/src/app/pdf-summary/page.tsx
@@ -1,0 +1,11 @@
+import PdfSummaryForm from "../components/PdfSummaryForm";
+
+export default function PdfSummaryPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen container mx-auto">
+      <h3 className="text-2xl font-bold text-gray-100 mb-4">PDF Summarizer</h3>
+      <p className="text-gray-400 mb-4 text-center">Upload a PDF and get a concise summary with bullet points.</p>
+      <PdfSummaryForm />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- configure pdf summarizer API route to run on Node runtime
- add a pdf-parse module declaration
- add AGENTS instructions

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b98f40c108324b87fd316904b33a9