### PR TITLE
Add calendar view for scheduled tweets

### DIFF
--- a/src/app/components/Calendar.tsx
+++ b/src/app/components/Calendar.tsx
@@ -1,0 +1,73 @@
+'use client';
+import { useState } from 'react';
+
+interface TweetItem {
+  content: string;
+  date: string;
+}
+
+interface CalendarProps {
+  tweets: TweetItem[];
+}
+
+const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+export default function Calendar({ tweets }: CalendarProps) {
+  const [current, setCurrent] = useState(() => new Date());
+
+  const startOfMonth = new Date(current.getFullYear(), current.getMonth(), 1);
+  const endOfMonth = new Date(current.getFullYear(), current.getMonth() + 1, 0);
+  const daysInMonth = endOfMonth.getDate();
+  const firstDayIndex = startOfMonth.getDay();
+
+  const events: Record<number, TweetItem[]> = {};
+  tweets.forEach((t) => {
+    const d = new Date(t.date);
+    if (d.getFullYear() === current.getFullYear() && d.getMonth() === current.getMonth()) {
+      const day = d.getDate();
+      if (!events[day]) events[day] = [];
+      events[day].push(t);
+    }
+  });
+
+  const cells = [] as JSX.Element[];
+  for (let i = 0; i < firstDayIndex; i++) {
+    cells.push(<div key={'e' + i} />);
+  }
+  for (let day = 1; day <= daysInMonth; day++) {
+    const dayEvents = events[day] || [];
+    cells.push(
+      <div key={day} className="border border-gray-700 p-1 min-h-[80px] text-xs">
+        <div className="text-gray-400 text-right">{day}</div>
+        {dayEvents.map((evt, idx) => (
+          <div key={idx} className="text-gray-100 break-words">
+            {evt.content}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const prevMonth = () => setCurrent(new Date(current.getFullYear(), current.getMonth() - 1, 1));
+  const nextMonth = () => setCurrent(new Date(current.getFullYear(), current.getMonth() + 1, 1));
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-2">
+        <button onClick={prevMonth} className="px-2 py-1 bg-gray-800 rounded">Prev</button>
+        <div className="text-lg font-semibold">
+          {current.toLocaleString('default', { month: 'long', year: 'numeric' })}
+        </div>
+        <button onClick={nextMonth} className="px-2 py-1 bg-gray-800 rounded">Next</button>
+      </div>
+      <div className="grid grid-cols-7 gap-1 mb-1 text-center text-sm text-gray-300">
+        {dayNames.map((d) => (
+          <div key={d}>{d}</div>
+        ))}
+      </div>
+      <div className="grid grid-cols-7 gap-1">
+        {cells}
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/NavTabs.tsx
+++ b/src/app/components/NavTabs.tsx
@@ -1,0 +1,29 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const tabs = [
+  { href: '/', label: 'Generate Tweets' },
+  { href: '/scheduled', label: 'Scheduled Tweets' },
+];
+
+export default function NavTabs() {
+  const pathname = usePathname();
+  return (
+    <nav className="flex justify-center space-x-4 mb-6 mt-4">
+      {tabs.map((tab) => (
+        <Link
+          key={tab.href}
+          href={tab.href}
+          className={`px-3 py-1 rounded-md text-sm ${
+            pathname === tab.href
+              ? 'bg-gray-800 text-white'
+              : 'text-gray-400 hover:text-white'
+          }`}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import NavTabs from "./components/NavTabs";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <NavTabs />
         {children}
       </body>
     </html>

--- a/src/app/lib/googleSheets.ts
+++ b/src/app/lib/googleSheets.ts
@@ -29,3 +29,37 @@ export async function appendTweetToSheet(tweet: string, date: string) {
     },
   });
 }
+
+export async function getScheduledTweets() {
+  const spreadsheetId = process.env.GOOGLE_SHEETS_SPREADSHEET_ID;
+  const clientEmail = process.env.GOOGLE_SHEETS_CLIENT_EMAIL;
+  const privateKey = process.env.GOOGLE_SHEETS_PRIVATE_KEY;
+  const sheetName = process.env.GOOGLE_SHEETS_SHEET_NAME || 'Sheet1';
+
+  if (!spreadsheetId || !clientEmail || !privateKey) {
+    throw new Error('Google Sheets environment variables not configured');
+  }
+
+  const auth = new google.auth.JWT(
+    clientEmail,
+    undefined,
+    privateKey.replace(/\\n/g, '\n'),
+    ['https://www.googleapis.com/auth/spreadsheets']
+  );
+
+  const sheets = google.sheets({ version: 'v4', auth });
+  const res = await sheets.spreadsheets.values.get({
+    spreadsheetId,
+    range: `${sheetName}!A:C`,
+  });
+
+  const rows = res.data.values || [];
+  const tweets: { content: string; date: string }[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const [content, date] = rows[i];
+    if (content && date) {
+      tweets.push({ content, date });
+    }
+  }
+  return tweets;
+}

--- a/src/app/scheduled/page.tsx
+++ b/src/app/scheduled/page.tsx
@@ -1,0 +1,11 @@
+import Calendar from '../components/Calendar';
+import { getScheduledTweets } from '../lib/googleSheets';
+
+export default async function ScheduledPage() {
+  const tweets = await getScheduledTweets();
+  return (
+    <div className="flex flex-col items-center min-h-screen container mx-auto">
+      <Calendar tweets={tweets} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `NavTabs` component for navigation between generator and schedule
- update layout to show tabs
- create `Calendar` component to display scheduled tweets in a month view
- add `getScheduledTweets` helper for fetching Google Sheet data
- create `/scheduled` page showing the calendar

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bc6a42f9083249751b3761b64d701