### PR TITLE
Add scheduled tweets view

### DIFF
--- a/src/app/api/scheduled/route.ts
+++ b/src/app/api/scheduled/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { getScheduledTweets } from "../../lib/googleSheets";
+
+export async function GET() {
+  try {
+    const tweets = await getScheduledTweets();
+    return NextResponse.json({ tweets });
+  } catch (error) {
+    console.error("Error fetching scheduled tweets:", error);
+    return NextResponse.json(
+      { message: "Failed to fetch scheduled tweets" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/components/ScheduledTweets.tsx
+++ b/src/app/components/ScheduledTweets.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { useEffect, useState } from "react";
+
+interface ScheduledTweet {
+  content: string;
+  date: string;
+  posted: boolean;
+}
+
+const BASE_URL: string = process.env.NEXT_PUBLIC_BASE_URL || "";
+
+const ScheduledTweets = () => {
+  const [tweets, setTweets] = useState<ScheduledTweet[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const fetchTweets = async () => {
+      try {
+        const response = await fetch(`${BASE_URL}/api/scheduled`);
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+        setTweets(data.tweets || []);
+      } catch (error) {
+        console.error("Failed to fetch scheduled tweets:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchTweets();
+  }, []);
+
+  if (loading) {
+    return <div className="text-gray-300">Loading...</div>;
+  }
+
+  if (tweets.length === 0) {
+    return <div className="text-gray-300">No scheduled tweets found.</div>;
+  }
+
+  return (
+    <div className="w-full max-w-2xl flex flex-col gap-2">
+      {tweets.map((tweet, idx) => (
+        <div
+          key={idx}
+          className="border-2 border-gray-900 bg-transparent p-2 rounded-lg"
+        >
+          <p className="text-gray-100 whitespace-pre-wrap">{tweet.content}</p>
+          <p className="text-gray-400 text-sm mt-1">
+            Date: {tweet.date} {tweet.posted ? "(posted)" : ""}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ScheduledTweets;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,12 @@
+"use client";
+import { useState } from "react";
 import { RiStarFill, RiTwitterXLine } from "react-icons/ri";
 import InteractiveForm from "./components/InteractiveForm";
+import ScheduledTweets from "./components/ScheduledTweets";
 
 export default function Home() {
+  const [tab, setTab] = useState<"generate" | "scheduled">("generate");
+
   return (
     <div className="flex flex-col items-center  justify-center min-h-screen container mx-auto ">
       <RiTwitterXLine size={50} color="white" className="mb-4" />
@@ -14,8 +19,24 @@ export default function Home() {
           Discover creative and impactful ideas tailored to your needs.
         </p>
 
-        <InteractiveForm />
+        <div className="flex gap-2 mb-4">
+          <button
+            onClick={() => setTab("generate")}
+            className={`px-4 py-2 rounded ${tab === "generate" ? "bg-gray-800 text-white" : "bg-gray-700 text-gray-300"}`}
+          >
+            Generate
+          </button>
+          <button
+            onClick={() => setTab("scheduled")}
+            className={`px-4 py-2 rounded ${tab === "scheduled" ? "bg-gray-800 text-white" : "bg-gray-700 text-gray-300"}`}
+          >
+            Scheduled
+          </button>
+        </div>
+
+        {tab === "generate" ? <InteractiveForm /> : <ScheduledTweets />}
       </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- add API route to fetch scheduled tweets from Google Sheets
- expose helper `getScheduledTweets`
- show a tab on the home page to list scheduled tweets

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c0d30aca4832490f850424d062e7e