### PR TITLE
Add scheduled tweets fetch via webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ The scheduler uses the Twitter environment variables above to post tweets
 automatically based on entries in your Google Sheet.
 
 The web app now includes a **Scheduled** tab where you can view upcoming tweets
-from your spreadsheet.
+from your spreadsheet. When you provide a Google Sheets webhook on the Generate
+page, the URL is stored locally so the Scheduled tab can fetch tweets from the
+same sheet.
 
 ## Screenshots
 

--- a/src/app/api/scheduled/route.ts
+++ b/src/app/api/scheduled/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from "next/server";
 import { getScheduledTweets } from "../../lib/googleSheets";
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
-    const tweets = await getScheduledTweets();
+    const { searchParams } = new URL(req.url);
+    const webhookUrl = searchParams.get("webhookUrl") || process.env.GOOGLE_SHEETS_WEBHOOK_URL;
+    const tweets = await getScheduledTweets(webhookUrl || undefined);
     return NextResponse.json({ tweets });
   } catch (error) {
     console.error("Error fetching scheduled tweets:", error);

--- a/src/app/components/InteractiveForm.tsx
+++ b/src/app/components/InteractiveForm.tsx
@@ -71,8 +71,20 @@ const InteractiveForm = () => {
   };
 
   useEffect(() => {
+    const storedWebhook = typeof window !== 'undefined' ? localStorage.getItem('webhookUrl') || '' : '';
+    setWebhookUrl(storedWebhook);
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      if (webhookUrl) {
+        localStorage.setItem('webhookUrl', webhookUrl);
+      } else {
+        localStorage.removeItem('webhookUrl');
+      }
+    }
+  }, [webhookUrl]);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/app/components/ScheduledTweets.tsx
+++ b/src/app/components/ScheduledTweets.tsx
@@ -18,7 +18,12 @@ const ScheduledTweets = () => {
   useEffect(() => {
     const fetchTweets = async () => {
       try {
-        const response = await fetch(`${BASE_URL}/api/scheduled`);
+        const webhook =
+          typeof window !== "undefined"
+            ? localStorage.getItem("webhookUrl") || ""
+            : "";
+        const query = webhook ? `?webhookUrl=${encodeURIComponent(webhook)}` : "";
+        const response = await fetch(`${BASE_URL}/api/scheduled${query}`);
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }

--- a/src/app/lib/googleSheets.ts
+++ b/src/app/lib/googleSheets.ts
@@ -36,7 +36,23 @@ export interface ScheduledTweet {
   posted: boolean;
 }
 
-export async function getScheduledTweets(): Promise<ScheduledTweet[]> {
+export async function getScheduledTweets(webhookUrl?: string): Promise<ScheduledTweet[]> {
+  if (webhookUrl) {
+    const response = await fetch(webhookUrl);
+    if (!response.ok) {
+      throw new Error('Failed to fetch scheduled tweets via webhook');
+    }
+    const data = await response.json();
+    if (!Array.isArray(data)) {
+      throw new Error('Unexpected data format from webhook');
+    }
+    return data.map((item: any) => ({
+      content: item.tweet ?? item.content ?? '',
+      date: item.date ?? '',
+      posted: (item.posted ?? item.Posted ?? '').toString().toLowerCase() === 'true',
+    }));
+  }
+
   const spreadsheetId = process.env.GOOGLE_SHEETS_SPREADSHEET_ID;
   const clientEmail = process.env.GOOGLE_SHEETS_CLIENT_EMAIL;
   const privateKey = process.env.GOOGLE_SHEETS_PRIVATE_KEY;


### PR DESCRIPTION
## Summary
- pull scheduled tweets using the webhook when provided
- persist webhook URL locally so both tabs share it
- adjust ScheduledTweets component to send the webhook URL
- document behaviour in README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c126dd0b48324b9935b6b0c55e8c1