### PR TITLE
Fix tweet_date prop for Google Sheets

### DIFF
--- a/src/app/api/google-sheets/route.ts
+++ b/src/app/api/google-sheets/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { appendTweetToSheet } from "../../lib/googleSheets";
 
 export async function POST(req: Request) {
-  const { tweet, date, webhookUrl: clientWebhookUrl } = await req.json();
+  const { tweet, tweet_date: date, webhookUrl: clientWebhookUrl } = await req.json();
   const webhookUrl = clientWebhookUrl || process.env.GOOGLE_SHEETS_WEBHOOK_URL;
 
   if (!tweet) {
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ tweet, date }),
+        body: JSON.stringify({ tweet, tweet_date: date }),
       });
 
       if (!response.ok) {

--- a/src/app/components/InteractiveForm.tsx
+++ b/src/app/components/InteractiveForm.tsx
@@ -35,7 +35,7 @@ const InteractiveForm = () => {
   const exportTweet = async (tweet: string) => {
     const loadingToast = toast.loading("Saving tweet...");
     try {
-      const payload = { tweet, date: selectedDate, webhookUrl };
+    const payload = { tweet, tweet_date: selectedDate, webhookUrl };
       const response = await fetch(`${BASE_URL}/api/google-sheets`, {
         method: "POST",
         headers: {


### PR DESCRIPTION
## Summary
- rename date field sent to Google Sheets
- expect `tweet_date` on the backend

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c1b917c708324aaef7a642385f6d8