### PR TITLE
Fix webhooks saving tweet date

### DIFF
--- a/src/app/api/google-sheets/route.ts
+++ b/src/app/api/google-sheets/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { appendTweetToSheet } from "../../lib/googleSheets";
 
 export async function POST(req: Request) {
-  const { tweet, tweet_date: date, webhookUrl: clientWebhookUrl } = await req.json();
+  const { tweet, date, webhookUrl: clientWebhookUrl } = await req.json();
   const webhookUrl = clientWebhookUrl || process.env.GOOGLE_SHEETS_WEBHOOK_URL;
 
   if (!tweet) {
@@ -14,13 +14,13 @@ export async function POST(req: Request) {
 
   if (webhookUrl) {
     try {
-      const response = await fetch(webhookUrl, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ tweet, tweet_date: date }),
-      });
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ tweet, date }),
+    });
 
       if (!response.ok) {
         throw new Error(`Failed to export tweet: ${response.statusText}`);

--- a/src/app/components/InteractiveForm.tsx
+++ b/src/app/components/InteractiveForm.tsx
@@ -37,7 +37,7 @@ const InteractiveForm = () => {
   const exportTweet = async (tweet: string) => {
     const loadingToast = toast.loading("Saving tweet...");
     try {
-    const payload = { tweet, tweet_date: selectedDate, webhookUrl };
+    const payload = { tweet, date: selectedDate, webhookUrl };
       const response = await fetch(`${BASE_URL}/api/google-sheets`, {
         method: "POST",
         headers: {


### PR DESCRIPTION
## Summary
- unify field naming for webhook requests

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c3c9fe7148324bdac720732000a8e