### PR TITLE
Fix tweet date export

### DIFF
--- a/src/app/api/google-sheets/route.ts
+++ b/src/app/api/google-sheets/route.ts
@@ -2,7 +2,13 @@ import { NextResponse } from "next/server";
 import { appendTweetToSheet } from "../../lib/googleSheets";
 
 export async function POST(req: Request) {
-  const { tweet, date, webhookUrl: clientWebhookUrl } = await req.json();
+  const {
+    tweet,
+    date,
+    tweet_date,
+    webhookUrl: clientWebhookUrl,
+  } = await req.json();
+  const finalDate: string | undefined = date || tweet_date;
   const webhookUrl = clientWebhookUrl || process.env.GOOGLE_SHEETS_WEBHOOK_URL;
 
   if (!tweet) {
@@ -19,7 +25,11 @@ export async function POST(req: Request) {
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ tweet, date }),
+      body: JSON.stringify({
+        tweet,
+        date: finalDate,
+        tweet_date: finalDate,
+      }),
     });
 
       if (!response.ok) {
@@ -49,7 +59,7 @@ export async function POST(req: Request) {
   }
 
   try {
-    await appendTweetToSheet(tweet, date);
+    await appendTweetToSheet(tweet, finalDate || "");
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Error exporting tweet to Google Sheets:", error);

--- a/src/app/components/InteractiveForm.tsx
+++ b/src/app/components/InteractiveForm.tsx
@@ -37,7 +37,12 @@ const InteractiveForm = () => {
   const exportTweet = async (tweet: string) => {
     const loadingToast = toast.loading("Saving tweet...");
     try {
-    const payload = { tweet, date: selectedDate, webhookUrl };
+    const payload = {
+      tweet,
+      date: selectedDate,
+      tweet_date: selectedDate,
+      webhookUrl,
+    };
       const response = await fetch(`${BASE_URL}/api/google-sheets`, {
         method: "POST",
         headers: {


### PR DESCRIPTION
## Summary
- include the date under `tweet_date` for backward compatibility with webhook scripts
- support `tweet_date` on the backend when exporting to sheets

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c4000d3908324aee0fd86c521937b