### PR TITLE
Add ts-node scheduler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ specified worksheet.
 The scheduler uses the Twitter environment variables above to post tweets
 automatically based on entries in your Google Sheet.
 
+Run the scheduler using:
+
+```bash
+npm run start:scheduler
+```
+
 The web app now includes a **Scheduled** tab where you can view upcoming tweets
 from your spreadsheet. When you provide a Google Sheets webhook on the Generate
 page, the URL is stored locally so the Scheduled tab can fetch tweets from the

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "eslint-config-next": "15.1.5",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5"
+        "typescript": "^5",
+        "ts-node": "^10.9.1"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "start:scheduler": "node src/app/lib/scheduler.ts"
+    "start:scheduler": "ts-node src/app/lib/scheduler.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
@@ -32,6 +32,7 @@
     "eslint-config-next": "15.1.5",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "ts-node": "^10.9.1"
   }
 }


### PR DESCRIPTION
## Summary
- add `ts-node` to dev dependencies
- run scheduler via `ts-node`
- document scheduler command in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c45e0f22483248d97b9605b5f197d