### PR TITLE
Remove unused API_KEY

### DIFF
--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -6,7 +6,6 @@ import { NextResponse } from "next/server";
 // const RATE_LIMIT = 25; // maximum number of requests in window
 // const RATE_LIMIT_WINDOW = 60; // time in seconds
 
-const API_KEY: string = process.env.OPENAI_API_KEY || "";
 interface ResponseType {
   description :string,
   options: Record<string,string>,


### PR DESCRIPTION
## Summary
- delete unused `API_KEY` constant
- keep using the `apiKey` from the request body when creating OpenAI client

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c45e2b45c8324b5af1605f9f8fe50