### PR TITLE
Remove unused Gemini dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # AI-Powered Tweet Generator
 
-An AI-driven tool that generates creative and engaging tweet ideas based on user-provided descriptions. This app leverages Google's generative AI model to quickly craft impactful tweets for various themes and tones. With a focus on speed and ease of use, it helps users create viral content effortlessly for social media platforms.
+An AI-driven tool that generates creative and engaging tweet ideas based on user-provided descriptions. This app leverages OpenAI's GPT-4 model to quickly craft impactful tweets for various themes and tones. With a focus on speed and ease of use, it helps users create viral content effortlessly for social media platforms.
 
 ## Features
 
 - 📝 Generate engaging tweets instantly.
-- 🤖 Powered by advanced generative AI.
+ - 🤖 Powered by OpenAI's GPT-4.
 - ⏱️ Fast tweet suggestions in seconds.
 - 🎨 Customizable tweet tone options.
 - 🔒 Secure and private user data.
@@ -17,7 +17,7 @@ An AI-driven tool that generates creative and engaging tweet ideas based on user
 
 **Client:** NextJS, Typescript, TailwindCSS
 
-**Server:** NextJS, Typecript, Redis, Gemini
+**Server:** NextJS, TypeScript, Redis, OpenAI
 
 ## API Reference
 
@@ -68,7 +68,7 @@ An AI-driven tool that generates creative and engaging tweet ideas based on user
 To run this project, you will need to add the following environment variables to your .env file
 
 ```shell
-GEMINI_AI_API_KEY = "Your gemini api key"
+OPENAI_API_KEY = "Your OpenAI API key"
 REDIS_PORT =
 REDIS_HOST =
 REDIS_PASSWORD =

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "twitter-post-genai",
       "version": "0.1.0",
       "dependencies": {
-        "@google/generative-ai": "^0.21.0",
         "axios": "^1.7.9",
         "googleapis": "^132.0.0",
         "ioredis": "^5.4.2",
@@ -169,14 +168,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@google/generative-ai": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.21.0.tgz",
-      "integrity": "sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "start:scheduler": "node src/app/lib/scheduler.ts"
   },
   "dependencies": {
-    "@google/generative-ai": "^0.21.0",
     "openai": "^4.28.0",
     "axios": "^1.7.9",
     "googleapis": "^132.0.0",


### PR DESCRIPTION
## Summary
- remove `@google/generative-ai` package
- update README to reference OpenAI GPT-4 instead of Gemini

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c45e60c588324a429a475a8f91872