### PR TITLE
Ensure spreadsheet stores timestamp, tweet, and date

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,13 @@ same sheet.
 ## Spreadsheet Layout
 
 ```
-Row 1 (headers): tweet | date | posted
-Rows 2+ : tweet text | YYYY-MM-DD | TRUE/FALSE
+Row 1 (headers): timestamp_incoming_webhook | tweet | tweet_date
+Rows 2+ : auto timestamp | tweet text | YYYY-MM-DD
 ```
 
 The first row must contain these headers because `getScheduledTweets` skips it
-when reading your sheet. Some webhook services send a `timestamp_incoming_webhook`
-field&mdash;map this value to the `date` column.
+when reading your sheet. The timestamp is generated when you click **Send to
+Sheets** so your spreadsheet always records when each tweet was exported.
 
 ## Screenshots
 

--- a/src/app/components/InteractiveForm.tsx
+++ b/src/app/components/InteractiveForm.tsx
@@ -38,8 +38,8 @@ const InteractiveForm = () => {
     const loadingToast = toast.loading("Saving tweet...");
     try {
     const payload = {
+      timestamp_incoming_webhook: new Date().toISOString(),
       tweet,
-      date: selectedDate,
       tweet_date: selectedDate,
       webhookUrl,
     };


### PR DESCRIPTION
## Summary
- add columns `timestamp_incoming_webhook`, `tweet`, and `tweet_date` when sending tweets to Google Sheets
- include timestamp when exporting from the UI
- validate the payload in the API route
- update Google Sheets helper to create headers and append the three columns
- document the new spreadsheet layout

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_683cf657e7948324a0e0c1da2033a382