### PR TITLE
List all tweets on scheduled tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Run the scheduler using:
 npm run start:scheduler
 ```
 
-The web app now includes a **Scheduled** tab where you can view upcoming tweets
+The web app now includes a **Scheduled** tab where you can view tweets
 from your spreadsheet. When you provide a Google Sheets webhook on the Generate
 page, the URL is stored locally so the Scheduled tab can fetch tweets from the
 same sheet.

--- a/src/app/components/ScheduledTweets.tsx
+++ b/src/app/components/ScheduledTweets.tsx
@@ -47,18 +47,14 @@ const ScheduledTweets = () => {
   }
 
   return (
-    <div className="w-full max-w-2xl flex flex-col gap-2">
-      {tweets.map((tweet, idx) => (
-        <div
-          key={idx}
-          className="border-2 border-gray-900 bg-transparent p-2 rounded-lg"
-        >
-          <p className="text-gray-100 whitespace-pre-wrap">{tweet.content}</p>
-          <p className="text-gray-400 text-sm mt-1">
-            Date: {tweet.date} {tweet.posted ? "(posted)" : ""}
-          </p>
-        </div>
-      ))}
+    <div className="w-full max-w-2xl">
+      <ul className="list-disc list-inside space-y-1">
+        {tweets.map((tweet, idx) => (
+          <li key={idx} className="text-gray-100 whitespace-pre-wrap">
+            {tweet.content}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- simplify display on Scheduled tab to just list tweet text
- clarify README that the Scheduled tab lists tweets

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cf741aa788324b422e966d25eec08