### PR TITLE
Fix TypeScript linter error in googleSheets

### DIFF
--- a/src/app/lib/googleSheets.ts
+++ b/src/app/lib/googleSheets.ts
@@ -124,7 +124,7 @@ export async function getScheduledTweets(webhookUrl?: string): Promise<Scheduled
       console.log('Received data from webhook:', data);
       
       // Handle both direct array and object containing tweets array
-      let tweetsArray: any[];
+      let tweetsArray: WebhookTweet[];
       if (Array.isArray(data)) {
         tweetsArray = data;
       } else if (data && typeof data === 'object' && Array.isArray(data.tweets)) {


### PR DESCRIPTION
## Summary
- fix ESLint error in `googleSheets.ts` by specifying `WebhookTweet[]`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d009e6ca48324a37b75a5da3c79da