### PR TITLE
List column B in scheduled tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Run the scheduler using:
 npm run start:scheduler
 ```
 
-The web app now includes a **Scheduled** tab where you can view upcoming tweets
-from your spreadsheet. When you provide a Google Sheets webhook on the Generate
-page, the URL is stored locally so the Scheduled tab can fetch tweets from the
-same sheet.
+The web app now includes a **Scheduled** tab where you can view tweets
+from your spreadsheet. It simply lists everything found in column B.
+When you provide a Google Sheets webhook on the Generate page, the URL is stored
+locally so the Scheduled tab can fetch tweets from the same sheet.
 
 ## Spreadsheet Layout
 

--- a/src/app/components/ScheduledTweets.tsx
+++ b/src/app/components/ScheduledTweets.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { useEffect, useState } from "react";
 
+// Represents a single row from the sheet. `content` holds the value from
+// column B which contains the tweet text.
 interface ScheduledTweet {
   content: string;
   date: string;
@@ -47,18 +49,14 @@ const ScheduledTweets = () => {
   }
 
   return (
-    <div className="w-full max-w-2xl flex flex-col gap-2">
-      {tweets.map((tweet, idx) => (
-        <div
-          key={idx}
-          className="border-2 border-gray-900 bg-transparent p-2 rounded-lg"
-        >
-          <p className="text-gray-100 whitespace-pre-wrap">{tweet.content}</p>
-          <p className="text-gray-400 text-sm mt-1">
-            Date: {tweet.date} {tweet.posted ? "(posted)" : ""}
-          </p>
-        </div>
-      ))}
+    <div className="w-full max-w-2xl">
+      <ul className="list-disc list-inside space-y-1">
+        {tweets.map((tweet, idx) => (
+          <li key={idx} className="text-gray-100 whitespace-pre-wrap">
+            {tweet.content}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };

--- a/src/app/lib/googleSheets.ts
+++ b/src/app/lib/googleSheets.ts
@@ -125,8 +125,10 @@ export async function getScheduledTweets(webhookUrl?: string): Promise<Scheduled
 
   const rows = res.data.values || [];
   return rows.slice(1).map((row) => ({
-    content: row[0] || '',
-    date: row[1] || '',
+    // Use column B as the tweet text so the Scheduled tab
+    // simply lists everything in that column.
+    content: row[1] || '',
+    date: row[0] || '',
     posted: (row[2] || '').toLowerCase() === 'true',
   }));
 }


### PR DESCRIPTION
## Summary
- add a note that Scheduled tab shows column B
- clarify ScheduledTweets type comment
- read column B for tweet text in `getScheduledTweets`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cf741aa788324b422e966d25eec08